### PR TITLE
Add GitHub project card options

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is designed to be used in conjunction with other actions that output to a f
 Especially if that output can be formatted as [GitHub flavoured Markdown](https://help.github.com/en/articles/basic-writing-and-formatting-syntax).
 This action will create an issue if a file exists at a specified path.
 The content of the issue will be taken from the file as-is.
+If project variables are specified, a card will be added to a project.
 If the file does not exist the action exits silently.
 
 ## Usage
@@ -19,6 +20,8 @@ If the file does not exist the action exits silently.
         ISSUE_TITLE: An example issue
         ISSUE_CONTENT_FILEPATH: ./example-content/output.md
         ISSUE_LABELS: report, automated issue
+        PROJECT_NAME: Example Project
+        PROJECT_COLUMN_NAME: To do
 ```
 
 #### Environment variables
@@ -27,6 +30,8 @@ If the file does not exist the action exits silently.
 - `ISSUE_CONTENT_FILEPATH` (**required**) - The file path to the issue content
 - `ISSUE_LABELS` - A comma separated list of labels to apply
 - `ISSUE_ASSIGNEES` - A comma separated list of assignees (GitHub usernames)
+- `PROJECT_NAME` - The name of a project to add a project card to (Requires `PROJECT_COLUMN_NAME`)
+- `PROJECT_COLUMN_NAME` - The name of the project column to add the card to
 
 ## Actions that pair with this action
 

--- a/create-issue-from-file.py
+++ b/create-issue-from-file.py
@@ -13,6 +13,8 @@ issue_content_path = os.environ['ISSUE_CONTENT_FILEPATH']
 # Fetch optional environment variables
 issue_labels = os.environ.get('ISSUE_LABELS')
 issue_assignees = os.environ.get('ISSUE_ASSIGNEES')
+project_name = os.environ.get('PROJECT_NAME')
+project_column_name = os.environ.get('PROJECT_COLUMN_NAME')
 
 # If the file does not exist there is no issue to create
 if not Path(issue_content_path).is_file():
@@ -47,3 +49,31 @@ if issue_assignees is not None:
     # Assign issue
     print("Assigning issue to assignees")
     issue.edit(assignees=assignees_list)
+
+if project_name is not None and project_column_name is not None:
+    # Locate the project by name
+    project = None
+    for project_item in repo.get_projects("all"):
+        if project_item.name == project_name:
+            project = project_item
+            break
+
+    if not project:
+        print("Project not found")
+        exit(0)
+
+    # Locate the column by name
+    column = None
+    for column_item in project.get_columns():
+        if column_item.name == project_column_name:
+            column = column_item
+            break
+
+    if not column:
+        print("Project column not found")
+        exit(0)
+
+    # Add the issue to the project
+    card = column.create_card(content_id=issue.id, content_type="Issue")
+    print("Added issue %d to project \"%s\" under column \"%s\"" \
+        % (issue.number, project.name, column.name))


### PR DESCRIPTION
My use-case involved adding new issues to a project board, so I added the functionality.  I hope it's useful for others that may have a similar case.

```yaml
    - name: Create Issue From File
      uses: sover02/create-issue-from-file@add_github_project_card_option
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        ISSUE_TITLE: An example issue
        ISSUE_CONTENT_FILEPATH: ./example-content/output.md
        ISSUE_LABELS: report, automated issue
        PROJECT_NAME: Example Project
        PROJECT_COLUMN_NAME: To do
```

![image](https://user-images.githubusercontent.com/8732504/69463580-f0af1080-0d49-11ea-87b6-9ba9738cbbeb.png)
