### PR TITLE
Support update existing open issue with same title

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
   repository:
     description: 'The target GitHub repository'
     default: ${{ github.repository }}
+  update-existing:
+    description: 'Update an open existing issue with the same title if it exists'
+    required: false
+    default: false
   issue-number:
     description: 'The issue number of an existing issue to update'
   title:


### PR DESCRIPTION
Solving issue https://github.com/peter-evans/create-issue-from-file/issues/298 and this feature is compatible with input `issue-number`. The logic looks like this:

```
If has input issue-number:
  update issue of issue-number
else if input update-existing is true:
  try find the first open issue with same title
  if get a issue:
    update it
  else:
    create new issue
else:
  create new issue
```

But I just think if this feature exists, the `issue-number` input parameter may be unnecessary...